### PR TITLE
change line comment to # and disable block comments as they are not supported

### DIFF
--- a/capnp.configuration.json
+++ b/capnp.configuration.json
@@ -1,12 +1,7 @@
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
-        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [
-            "/*",
-            "*/"
-        ]
+        "lineComment": "#"
     },
     // symbols used as brackets
     "brackets": [


### PR DESCRIPTION
Thanks for making this extension. This fixes commenting lines using ctrl+/.